### PR TITLE
Fix aria-label for DeepWiki link

### DIFF
--- a/tampermonkey-script.js
+++ b/tampermonkey-script.js
@@ -50,7 +50,7 @@ function createGoDeepWikiDOM() {
       <a href="${deepWikiUrl}"
         target="_blank"
         rel="nofollow"
-        aria-label="Go DeepDeepwikiWiki"
+        aria-label="Go DeepWiki"
         data-view-component="true"
         class="tooltipped tooltipped-sw btn-sm btn">
         Go Deepwiki


### PR DESCRIPTION
这个标签好像多复制了一个 deepwiki，虽然没有对功能有影响，但是对于强迫症非常不友好